### PR TITLE
Removed setting of remote URL in bump

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,9 +39,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
       - id: get_tag
         run: echo "release_tag=$(git describe --tags)" >> "$GITHUB_OUTPUT"
-      - run: |
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}
-          git push origin main
+      - run: git push origin main
 
   github-release:
     needs: bump


### PR DESCRIPTION
I suspect that the previous `set-url` command is what was blocking the CI/CD pipeline from running before. This would have caused pushes to the repo to be done with the auto-generated Github token rather than the deploy key used when checking out the repository.