### PR TITLE
Prevent release workflow when commit is tagged

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "!**"
 
 jobs:
   test:


### PR DESCRIPTION
Added a rule to the release workflow to prevent it from being triggered when a tagged commit is pushed. This is to prevent a feedback loop as the only cases where tagged commits should be pushed is within the action itself.

Thanks to [@starikcetin's comment](https://github.com/orgs/community/discussions/25615#discussioncomment-3397691) for explaining this method.